### PR TITLE
Add option for advertising tags

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -128,6 +128,11 @@ This option (if set) configures tailscale to use its userspace networking mode. 
 
 See [Userspace networking (container) mode](https://tailscale.com/kb/1112/userspace-networking/). for more information.
 
+### Option: `tags`
+This option (if set) configures tailscale to advertise the given tags. The format is the same as for `tailscale up --advertise-tags`: all tags prefixed with `tag:` and separated with commas (ex: `tag:server,tag:hass`).
+
+See [Server role accounts with ACL tags](https://tailscale.com/kb/1068/acl-tags/) for more information.
+
 ## How to connect your Home Assistant App (iOS)
 
 To ensure you can access Home Assistant from your mobile app when you're using Tailscale away from home, or when you're at home and have the app turned off: 

--- a/tailscale/config.json
+++ b/tailscale/config.json
@@ -26,6 +26,7 @@
         "hostname": "str?",
         "force_reauth": "bool?",
         "accept_routes": "bool?",
-        "userspace_networking": "bool?"
+        "userspace_networking": "bool?",
+        "tags": "str?"
     }
 }

--- a/tailscale/run.sh
+++ b/tailscale/run.sh
@@ -43,6 +43,10 @@ if bashio::config.has_value 'exit_node'; then
     TAILSCALE_FLAGS+=('-exit-node' "$(bashio::config 'exit_node')")
 fi
 
+if bashio::config.has_value 'tags'; then
+    TAILSCALE_FLAGS+=('-advertise-tags' "$(bashio::config 'tags')")
+fi
+
 if bashio::config.has_value 'port'; then
     TAILSCALED_FLAGS+=('-port', "$(bashio::config 'port')")
 fi


### PR DESCRIPTION
This adds the ability to set the `--advertise-tags` option on `tailscale up`. Usage is exactly the same as on the command line: tags prefixed with `tag:` and comma separated with no spaces.

```yaml
tags: "tag:server,tag:hass"
```

I have tested this with tailscale v1.18.1 on my own instance.