### PR TITLE
adding tailscale cert

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -133,6 +133,20 @@ This option (if set) configures tailscale to advertise the given tags. The forma
 
 See [Server role accounts with ACL tags](https://tailscale.com/kb/1068/acl-tags/) for more information.
 
+### Option: `cert_domain`
+
+This option (if set) configures tailscale to provision TLS certificates. The format is the same as for `tailscale cert <your-domain>`. It's necessary to set the exact domain under which your home assistant instance is running. 
+
+1. Go to [Feature Previews page](https://login.tailscale.com/admin/settings/features)
+2. Enable and choose a Tailnet domain alias
+3. Find your Home-Assistant in the [Machines tab](https://login.tailscale.com/admin/machines) and note under which name your device is reachable
+4. Your device should now be reachable under https://<device-name>.<tailnet-domain-alias>.ts.net (But with an invalid ssl certificate)
+5. Go to the options page of this addon and set the above domain at `cert_domain`
+6. Restart the addon and visit again the above domain. You should have now a valid ssl certificate.
+7. You should now have to new files under `/ssl` which you can use to configure any webserver.
+
+See [Enabling HTTPS](https://tailscale.com/kb/1153/enabling-https/) for more information.
+
 ## How to connect your Home Assistant App (iOS)
 
 To ensure you can access Home Assistant from your mobile app when you're using Tailscale away from home, or when you're at home and have the app turned off: 

--- a/tailscale/config.json
+++ b/tailscale/config.json
@@ -17,6 +17,9 @@
     "options": {
         "hostname": "homeassistant"
     },
+    "map": [
+        "ssl:rw"
+    ],
     "schema": {
         "advertise_routes": "str?",
         "advertise_exit_node": "bool?",

--- a/tailscale/run.sh
+++ b/tailscale/run.sh
@@ -6,7 +6,7 @@ set -eum
 CONFIG_PATH=/data/options.json
 TAILSCALE_SOCKET="/var/run/tailscale/tailscaled.sock"
 TAILSCALE_FLAGS=()
-TAILSCALED_FLAGS=("-state" "/data/tailscaled.state" "-socket" "$TAILSCALE_SOCKET")
+TAILSCALED_FLAGS=("-statedir" "/data" "-state" "/data/tailscaled.state" "-socket" "$TAILSCALE_SOCKET")
 
 # Parse config to construct `tailscale up` args
 if bashio::config.has_value 'auth_key'; then
@@ -65,6 +65,11 @@ tailscaled ${TAILSCALED_FLAGS[@]} &
 i=0
 while test $i -lt 12; do
     if test -e "$TAILSCALE_SOCKET"; then
+
+        if bashio::config.has_value 'cert_domain'; then
+          tailscale cert --cert-file "/ssl/$(bashio::config 'cert_domain').crt" --key-file "/ssl/$(bashio::config 'cert_domain').key" $(bashio::config 'cert_domain')
+        fi
+
         # bring up the tunnel and fd tailscaled
         tailscale -socket "$TAILSCALE_SOCKET" up ${TAILSCALE_FLAGS[@]} && fg
         exit $?


### PR DESCRIPTION
Hi,[ I did it 🚀](https://github.com/tsujamin/hass-addons/issues/28)

This MR adds support for [Tailscale HTTPS](https://tailscale.com/kb/1153/enabling-https/) which lets you to create a valid SSL Certificate authorised by a public Certificate Authority.

It's necessary to set the exact domain under which your Home Assistance is running at `cert_domain`:

```yaml
hostname: hassio
auth_key: tskey-....
cert_domain: hassio.your-domain.ts.net # <----
```

Then on startup it will create two files under `/ssl` which you can use for any Webserver.

E.g. Home Assistance `/config/configuration.yaml`:

```yml
http:
  server_port: 443
  ssl_certificate: /ssl/hassio.your-domain.ts.net
  ssl_key: /ssl/hassio.your-domain.ts.net
```

Your Home Assistance should now be available under https://hassio.your-domain.ts.net

I personally needed it for my running `vaultwarden` instance which needs the following options to set:

```yaml
certfile: hassio.your-domain.ts.net.crt
keyfile: hassio.your-domain.ts.net.key
ssl: true
```