### PR TITLE
Update DOCS about cert_domain (again)

### DIFF
--- a/tailscale/DOCS.md
+++ b/tailscale/DOCS.md
@@ -157,8 +157,8 @@ This option (if set) configures tailscale to provision TLS certificates. The for
 1. Go to [DNS tab](https://login.tailscale.com/admin/dns) in Tailscale's admin page
 2. Choose a **Tailnet name** and click **Enable HTTPS** under HTTPS Certificates
 3. Find your Home-Assistant in the [Machines tab](https://login.tailscale.com/admin/machines) and note under which name your device is reachable
-4. Your device should now be reachable under `https://<device-name>.<tailnet-domain-alias>.ts.net` (but with an invalid ssl certificate)
-5. Go to the **Configuration tab** of this add-on and set the above domain at `cert_domain` (only the domain, without the machine name)
+4. Your device should now be reachable under `https://<machine-name>.<tailnet-name>.ts.net` (but with an invalid ssl certificate)
+5. Go to the **Configuration tab** of this add-on and set the above domain (`<machine-name>.<tailnet-name>.ts.net`) at `cert_domain`
 6. Restart the add-on, you should now have two new files under `/ssl` which you can use to configure any webserver
 7. Visit again the above domain, you should have now a valid ssl certificate (if you encounter strange browser behaviour or strange error messages, try to clear all site related cookies, clear all browser cache, restart browser)
 


### PR DESCRIPTION
Yesterday I made an error in the PR #62, the text "(only the domain, without the machine name)" is simply false.

I repair it now, and repair some non-precise naming in the description also.

I'm sorry, I'm testing multiple Tailscale add-ons, and messed up the previous PR a little bit. :)